### PR TITLE
Restructuring Resource Releasing - fixing memory leaks

### DIFF
--- a/ssh_proxy_server/forwarders/base.py
+++ b/ssh_proxy_server/forwarders/base.py
@@ -1,3 +1,6 @@
+import logging
+
+from paramiko.agent import AgentRequestHandler
 from enhancements.modules import Module
 
 
@@ -11,11 +14,17 @@ class BaseForwarder(Module):
     def __init__(self, session):
         super().__init__()
         self.server_channel = session.ssh_client.transport.open_session()
+        # if session.agent:   # Exeprimental
+        #     logging.info("Forwarding agent to remote")
+        #     AgentRequestHandler(self.server_channel)
         self.channel = None
         self.session = session
 
     def forward(self):
         raise NotImplementedError
+
+    def close_session(self, channel):
+        self.session.close()
 
     def _closed(self, channel):
         return channel.closed or channel.eof_received or channel.eof_sent or not channel.active

--- a/ssh_proxy_server/forwarders/base.py
+++ b/ssh_proxy_server/forwarders/base.py
@@ -14,7 +14,7 @@ class BaseForwarder(Module):
     def __init__(self, session):
         super().__init__()
         self.server_channel = session.ssh_client.transport.open_session()
-        # if session.agent:   # Exeprimental
+        # if session.agent:   # Experimental
         #     logging.info("Forwarding agent to remote")
         #     AgentRequestHandler(self.server_channel)
         self.channel = None

--- a/ssh_proxy_server/forwarders/base.py
+++ b/ssh_proxy_server/forwarders/base.py
@@ -24,7 +24,7 @@ class BaseForwarder(Module):
         raise NotImplementedError
 
     def close_session(self, channel):
-        self.session.close()
+        channel.close()
 
     def _closed(self, channel):
         return channel.closed or channel.eof_received or channel.eof_sent or not channel.active

--- a/ssh_proxy_server/forwarders/scp.py
+++ b/ssh_proxy_server/forwarders/scp.py
@@ -74,7 +74,7 @@ class SCPBaseForwarder(BaseForwarder):
             sent += newsent
         return sent
 
-    def close_session(self, channel, status):
+    def close_session(self, channel, status=0):
         # pylint: disable=protected-access
         if channel.closed:
             return
@@ -107,6 +107,9 @@ class SCPBaseForwarder(BaseForwarder):
         channel.transport._send_user_message(message)
 
         channel._unlink()
+
+        super(SCPBaseForwarder, self).close_session(channel)
+        logging.debug("[chan %d] SCP closed", channel.get_id())
 
 
 class SCPForwarder(SCPBaseForwarder):

--- a/ssh_proxy_server/forwarders/ssh.py
+++ b/ssh_proxy_server/forwarders/ssh.py
@@ -69,10 +69,6 @@ class SSHForwarder(SSHBaseForwarder):
             buf = self.stderr(buf)
             self.session.ssh_channel.sendall_stderr(buf)
 
-    def close_session(self, channel):
-        channel.get_transport().close()
-        logging.info("session closed")
-
     def stdin(self, text):
         return text
 

--- a/ssh_proxy_server/interfaces/server.py
+++ b/ssh_proxy_server/interfaces/server.py
@@ -133,6 +133,7 @@ class ServerInterface(BaseServerInterface):
 
 class ProxySFTPServer(paramiko.SFTPServer):
     def start_subsystem(self, name, transport, channel):
+        self.server.session.sftp_client_ready.wait()
         self.server.session.sftp_client.subsystem_count += 1
         super().start_subsystem(name, transport, channel)
 

--- a/ssh_proxy_server/interfaces/server.py
+++ b/ssh_proxy_server/interfaces/server.py
@@ -141,4 +141,3 @@ class ProxySFTPServer(paramiko.SFTPServer):
         super().finish_subsystem()
         self.server.session.sftp_client.subsystem_count -= 1
         self.server.session.sftp_client.close()
-        self.server.session.close()

--- a/ssh_proxy_server/interfaces/server.py
+++ b/ssh_proxy_server/interfaces/server.py
@@ -141,3 +141,4 @@ class ProxySFTPServer(paramiko.SFTPServer):
         super().finish_subsystem()
         self.server.session.sftp_client.subsystem_count -= 1
         self.server.session.sftp_client.close()
+        self.server.session.close()

--- a/ssh_proxy_server/plugins/ssh/injectorshell.py
+++ b/ssh_proxy_server/plugins/ssh/injectorshell.py
@@ -42,7 +42,6 @@ class SSHInjectableForwarder(SSHForwarder):
         self.injector_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.injector_sock.bind((self.args.ssh_injector_net, 0))
         self.injector_sock.listen(5)
-        self.inject_running = True
 
         self.mirror_enabled = self.args.ssh_injector_enable_mirror
         self.queue = queue.Queue()
@@ -118,7 +117,6 @@ class SSHInjectableForwarder(SSHForwarder):
 
     def close_session(self, channel):
         super().close_session(channel)
-        self.inject_running = False
         for shell in self.injector_shells:
             shell.join()
         self.conn_thread.join()

--- a/ssh_proxy_server/plugins/ssh/injectorshell.py
+++ b/ssh_proxy_server/plugins/ssh/injectorshell.py
@@ -159,7 +159,7 @@ class InjectorShell(threading.Thread):
             self.terminate()
 
     def terminate(self):
-        if self.forwarder.session.running:
+        if self.forwarder.inject_running:
             self.forwarder.injector_shells.remove(self)
         self.client_channel.get_transport().close()
         logging.info("injector shell %s was closed", str(self.remote))

--- a/ssh_proxy_server/plugins/ssh/mirrorshell.py
+++ b/ssh_proxy_server/plugins/ssh/mirrorshell.py
@@ -83,7 +83,7 @@ class SSHMirrorForwarder(SSHForwarder):
         )
         try:
             while self.session.running:
-                readable = select.select([self.injector_sock], [], [])[0]
+                readable = select.select([self.injector_sock], [], [], 0.5)[0]
                 if len(readable) == 1 and readable[0] is self.injector_sock:
                     self.injector_client_sock, addr = self.injector_sock.accept()
 
@@ -118,7 +118,8 @@ class SSHMirrorForwarder(SSHForwarder):
         super().close_session(channel)
         logging.info("closing injector connection %s", self.injector_sock.getsockname())
         self.injector_sock.close()
-        self.inject_server.injector_channel.get_transport().close()
+        if self.inject_server:
+            self.inject_server.injector_channel.get_transport().close()
         self.conn_thread.join()
 
     def forward_stdout(self):

--- a/ssh_proxy_server/server.py
+++ b/ssh_proxy_server/server.py
@@ -116,7 +116,7 @@ class SSHProxyServer:
                 else:
                     logging.warning("(%s) session not started", session)
                     self._threads.remove(threading.current_thread())
-                #time.sleep(1)   # So the proxy server does not close the connection to fast
+                # Prevent client_loop errors: don't close proxy server -> client connection to fast
+                time.sleep(0.1)
         except Exception:
             logging.exception("error handling session creation")
-        logging.info("session closed")

--- a/ssh_proxy_server/server.py
+++ b/ssh_proxy_server/server.py
@@ -111,13 +111,12 @@ class SSHProxyServer:
                     elif session.scp and self.scp_interface:
                         session.scp = False
                         self.scp_interface(session).forward()
+                    while session.running:
+                        time.sleep(1)
                 else:
                     logging.warning("(%s) session not started", session)
                     self._threads.remove(threading.current_thread())
-                # Compromise, waiting for other channels to finish
-                # BUT only releases when server is shutdown (meh)
-                while session.running:
-                    time.sleep(1)
+                #time.sleep(1)   # So the proxy server does not close the connection to fast
         except Exception:
             logging.exception("error handling session creation")
         logging.info("session closed")

--- a/ssh_proxy_server/server.py
+++ b/ssh_proxy_server/server.py
@@ -95,6 +95,7 @@ class SSHProxyServer:
         except KeyboardInterrupt:
             self.running = False
         finally:
+            logging.info("Shutting down server ...")
             sock.close()
             for thread in self._threads[:]:
                 thread.join()
@@ -110,11 +111,13 @@ class SSHProxyServer:
                     elif session.scp and self.scp_interface:
                         session.scp = False
                         self.scp_interface(session).forward()
-                    while True:
-                        time.sleep(1)
                 else:
-                    logging.warning("Session not started")
+                    logging.warning("(%s) session not started", session)
                     self._threads.remove(threading.current_thread())
+                # Compromise, waiting for other channels to finish
+                # BUT only releases when server is shutdown (meh)
+                while session.running:
+                    time.sleep(1)
         except Exception:
-            logging.exception("error handling session")
+            logging.exception("error handling session creation")
         logging.info("session closed")

--- a/ssh_proxy_server/server.py
+++ b/ssh_proxy_server/server.py
@@ -116,7 +116,5 @@ class SSHProxyServer:
                 else:
                     logging.warning("(%s) session not started", session)
                     self._threads.remove(threading.current_thread())
-                # Prevent client_loop errors: don't close proxy server -> client connection to fast
-                time.sleep(0.1)
         except Exception:
             logging.exception("error handling session creation")

--- a/ssh_proxy_server/session.py
+++ b/ssh_proxy_server/session.py
@@ -134,6 +134,8 @@ class Session:
             logging.debug("(%s) session cleaning up agent ...", self)
             self.agent.close()
             logging.debug("(%s) session agent cleaned up", self)
+        # TODO: Unrelated to this method - clients on the proxy server are not terminated correctly/at all
+        # this can lead to a potential DoS attack on the proxy
 
     def __str__(self):
         return self.name

--- a/ssh_proxy_server/session.py
+++ b/ssh_proxy_server/session.py
@@ -44,7 +44,7 @@ class Session:
 
     @property
     def running(self):
-        # Using main channel status to determine session status (+ releasability of resources)
+        # Using status of main channels to determine session status (-> releasability of resources)
         # - often calculated, cpu heavy (?)
         ch_active = all([not ch.closed for ch in filter(None, [self.ssh_channel, self.scp_channel, self.sftp_channel])])
         return self.proxyserver.running and ch_active


### PR DESCRIPTION
This pull request mainly restructures the way the ssh-mitm server terminates and releases its connections (ssh, scp, sftp).

- Fixed memory leaks i.e leaking client connections when the session has already terminated which could have been abused as a Dos attack
- Redefined session.running status for more easy indication of termination

Additionally looked at and added features described in Issue #25 
- OpenSSH 8.4 Agent forwarding compatibility