### PR TITLE
AgentProxy - agent forwarding capabilities

### DIFF
--- a/ssh_proxy_server/authentication.py
+++ b/ssh_proxy_server/authentication.py
@@ -42,6 +42,12 @@ class Authenticator(Module):
             action='store_true',
             help='do not log credentials (usefull for presentations)'
         )
+        cls.PARSER.add_argument(
+            '--forward-agent',
+            dest='forward_agent',
+            action='store_true',
+            help='enables agent forwarding through the proxy'
+        )
 
     def __init__(self, session):
         super().__init__()

--- a/ssh_proxy_server/cli.py
+++ b/ssh_proxy_server/cli.py
@@ -102,9 +102,9 @@ def main():
     )
     parser.add_argument(
         '--request-agent',
-        dest='foreward_agent',
+        dest='request_agent',
         action='store_true',
-        help='enables agent forwarding'
+        help='request agent for public key authentication'
     )
     parser.add_argument(
         '--request-agent-breakin',
@@ -134,7 +134,7 @@ def main():
     else:
         logging.getLogger("paramiko").setLevel(logging.WARNING)
 
-    args.authenticator.REQUEST_AGENT = args.foreward_agent
+    args.authenticator.REQUEST_AGENT = args.request_agent
     if args.request_agent_breakin:
         args.authenticator.REQUEST_AGENT = True
         args.authenticator.REQUEST_AGENT_BREAKIN = True

--- a/ssh_proxy_server/forwarders/agent.py
+++ b/ssh_proxy_server/forwarders/agent.py
@@ -1,0 +1,43 @@
+import threading
+import time
+
+from paramiko.agent import Agent, AgentRequestHandler, AgentServerProxy, AgentClientProxy
+import logging
+import os
+
+class AgentProxy(object):
+
+    def __init__(self, transport) -> None:
+        self.agents = []
+        self.transport = transport
+        agent = AgentServerProxy(self.transport)
+        os.environ.update(agent.get_env())
+        agent.connect()
+
+        self.agents.append(agent)
+        agent = Agent()
+        self.keys = agent.get_keys()[:]
+
+        self.agents.append(agent)
+        # should be able to be closed now, but for some reason there is a race
+        # self.a.close()
+
+    def get_keys(self):
+        return self.keys
+
+    def forward_agent(self, chanClient):
+        logging.info("Forwarding agent to remote")
+        chanClient.request_forward_agent(self._forward_agent_handler)
+
+    def _forward_agent_handler(self, chanRemote):
+        agent = AgentServerProxy(self.transport)
+        os.environ.update(agent.get_env())
+        self.agents.append(AgentClientProxy(chanRemote))
+
+    def wait_for_agent(self, agent):
+        while agent._conn is None:
+            time.sleep(0.2)
+
+    def close(self):
+        for a in self.agents:
+            a.close()

--- a/ssh_proxy_server/forwarders/base.py
+++ b/ssh_proxy_server/forwarders/base.py
@@ -1,7 +1,5 @@
 import logging
-import time
 
-from paramiko.agent import AgentRequestHandler, AgentLocalProxy, AgentClientProxy
 from enhancements.modules import Module
 
 
@@ -15,7 +13,7 @@ class BaseForwarder(Module):
     def __init__(self, session):
         super().__init__()
         self.server_channel = session.ssh_client.transport.open_session()
-        if session.agent:   # Experimental
+        if session.authenticator.args.forward_agent:
             logging.info("Forwarding agent to remote")
             session.agent.forward_agent(self.server_channel)
         self.channel = None

--- a/ssh_proxy_server/forwarders/base.py
+++ b/ssh_proxy_server/forwarders/base.py
@@ -1,6 +1,7 @@
 import logging
+import time
 
-from paramiko.agent import AgentRequestHandler
+from paramiko.agent import AgentRequestHandler, AgentLocalProxy, AgentClientProxy
 from enhancements.modules import Module
 
 
@@ -14,9 +15,9 @@ class BaseForwarder(Module):
     def __init__(self, session):
         super().__init__()
         self.server_channel = session.ssh_client.transport.open_session()
-        # if session.agent:   # Experimental
-        #     logging.info("Forwarding agent to remote")
-        #     AgentRequestHandler(self.server_channel)
+        if session.agent:   # Experimental
+            logging.info("Forwarding agent to remote")
+            session.agent.forward_agent(self.server_channel)
         self.channel = None
         self.session = session
 

--- a/ssh_proxy_server/interfaces/server.py
+++ b/ssh_proxy_server/interfaces/server.py
@@ -58,7 +58,7 @@ class ServerInterface(BaseServerInterface):
         return False
 
     def check_channel_forward_agent_request(self, channel):
-        self.session.agent_requested = True
+        self.session.agent_requested.set()
         logging.debug("check_channel_forward_agent_request")
         return True
 

--- a/ssh_proxy_server/server.py
+++ b/ssh_proxy_server/server.py
@@ -45,6 +45,7 @@ class SSHProxyServer:
         self.scp_interface = scp_interface
         self.sftp_handler = sftp_handler
         self.sftp_interface = self.sftp_handler.get_interface() or sftp_interface
+        # Server Interface
         self.authentication_interface = authentication_interface
         self.authenticator = authenticator
         self.transparent = transparent

--- a/ssh_proxy_server/session.py
+++ b/ssh_proxy_server/session.py
@@ -1,11 +1,13 @@
 import logging
+import os
 import threading
 import time
 
 from paramiko import Transport, AUTH_SUCCESSFUL
-from paramiko.agent import AgentServerProxy
+from paramiko.agent import AgentServerProxy, Agent
 from paramiko.ssh_exception import ChannelException
 
+from ssh_proxy_server.forwarders.agent import AgentProxy
 from ssh_proxy_server.interfaces.server import ProxySFTPServer
 from ssh_proxy_server.plugins.session import cve202014145
 
@@ -81,8 +83,7 @@ class Session:
         if not self.agent and (self.authenticator.REQUEST_AGENT or self.authenticator.REQUEST_AGENT_BREAKIN):
             try:
                 if self.agent_requested.wait(1) or self.authenticator.REQUEST_AGENT_BREAKIN:
-                    self.agent = AgentServerProxy(self.transport)
-                    self.agent.connect()
+                    self.agent = AgentProxy(self.transport)
             except ChannelException:
                 logging.error("Breakin not successful! Closing ssh connection to client")
                 self.agent = None
@@ -138,13 +139,8 @@ class Session:
 
     def close(self):
         if self.agent:
-            logging.error("(%s) session cleaning up agent ... (because paramiko IO blocks, in a new Thread)", self)
-            self.agent._close()
-            # INFO: Agent closing sequence takes 15 minutes, due to blocking IO in paramiko
-            # Paramiko agent.py tries to connect to a UNIX_SOCKET; it should be created as well (prob) BUT never is
-            # Agents starts Thread -> leads to the socket.connect blocking; only returns after .join(1000) timeout
-            threading.Thread(target=self.agent.close).start()
-            # Can throw FileNotFoundError due to no verification (agent.py)
+            logging.error("(%s) session cleaning up agent", self)
+            self.agent.close()
             logging.debug("(%s) session agent cleaned up", self)
         if self.ssh_client:
             logging.debug("(%s) closing ssh client to remote", self)
@@ -153,7 +149,9 @@ class Session:
             # it can also only be a graceful exit if the ssh client has already been established
             if self.transport.completion_event.is_set() and self.transport.is_active():
                 self.transport.completion_event.clear()
-                self.transport.completion_event.wait()
+                while self.transport.is_active():
+                    if self.transport.completion_event.wait(0.1):
+                        break
         self.transport.close()
         logging.debug("(%s) session closed", self)
 

--- a/ssh_proxy_server/session.py
+++ b/ssh_proxy_server/session.py
@@ -1,10 +1,7 @@
 import logging
-import os
 import threading
-import time
 
 from paramiko import Transport, AUTH_SUCCESSFUL
-from paramiko.agent import AgentServerProxy, Agent
 from paramiko.ssh_exception import ChannelException
 
 from ssh_proxy_server.forwarders.agent import AgentProxy
@@ -139,7 +136,6 @@ class Session:
 
     def close(self):
         if self.agent:
-            logging.error("(%s) session cleaning up agent", self)
             self.agent.close()
             logging.debug("(%s) session agent cleaned up", self)
         if self.ssh_client:


### PR DESCRIPTION
Implemented agent forwarding support to the remote client via on demand authentication channels (just like normal OpenSSH agent forwarding behavior)
+ Simplified agent_wait

This implements features mentioned in #25; OpenSSH 8.4 SCP Agent Forwarding for remote to remote copy is not supported 