### PR TITLE
 Added OpenSSH 8.5 and 8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 ![SSH-MITM example](https://www.ssh-mitm.at/img/mitm-example.png)
 
 
+## Support Development
+
+If you want to support development, you can spend ether to my address: 0xeC6e9224623B6C1f4394882dA0Cf06793D5d1F83
+
+
 ## Give a Star! :star:
 This keeps me motivated in developing this tool. Thanks!
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Support Development
 
-If you want to support development, you can spend some Ethereum to my address: 0xeC6e9224623B6C1f4394882dA0Cf06793D5d1F83
+If you want to support development, you can spend some Ethereum: 0xeC6e9224623B6C1f4394882dA0Cf06793D5d1F83
 
 
 ## Give a Star! :star:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@
 ![SSH-MITM example](https://www.ssh-mitm.at/img/mitm-example.png)
 
 
-## Support Development
-
-If you want to support development, you can spend some Ethereum: 0xeC6e9224623B6C1f4394882dA0Cf06793D5d1F83
-
-
 ## Give a Star! :star:
 This keeps me motivated in developing this tool. Thanks!
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Support Development
 
-If you want to support development, you can spend ether to my address: 0xeC6e9224623B6C1f4394882dA0Cf06793D5d1F83
+If you want to support development, you can spend some Ethereum to my address: 0xeC6e9224623B6C1f4394882dA0Cf06793D5d1F83
 
 
 ## Give a Star! :star:

--- a/doc/CVE-2020-14145.rst
+++ b/doc/CVE-2020-14145.rst
@@ -25,14 +25,14 @@ CVE-2020-14145
                     <i class="fas fa-check"></i> integrated in SSH-MITM server
                 </p>
                 <p class="widget-49-meeting-text">
-                    The client side in OpenSSH 5.7 through 8.4 has an Observable Discrepancy
+                    The client side in OpenSSH 5.7 through 8.6 has an Observable Discrepancy
                     leading to an information leak in the algorithm negotiation.
                     This allows man-in-the-middle attackers to target initial connection
                     attempts (where no host key for the server has been cached by the client).
                 </p>
                 <span class="widget-49-pro-title"><b>Affected Software:</b></span>
                 <ul class="widget-49-meeting-points">
-                    <li class="widget-49-meeting-item"><b>OpenSSH</b> 5.7-8.4</li>
+                    <li class="widget-49-meeting-item"><b>OpenSSH</b> 5.7-8.6</li>
                 </ul>
             </div>
         </div>
@@ -41,7 +41,7 @@ CVE-2020-14145
 Description
 -----------
 
-A vulnerability in OpenSSH <= 8.4 allows a man in the middle attack to determine, if a client already has
+A vulnerability in OpenSSH <= 8.6 allows a man in the middle attack to determine, if a client already has
 prior knowledge of the remote hosts fingerprint.
 
 Using this information leak it is possible to ignore clients, which will show an error message during an man in the middle attack,

--- a/ssh_proxy_server/plugins/session/cve202014145.py
+++ b/ssh_proxy_server/plugins/session/cve202014145.py
@@ -7,7 +7,7 @@ from paramiko import ECDSAKey
 CVE = 'CVE-2020-14145'
 CLIENT_NAME = 'openssh'
 DEFAULT_ALGORITMS = [
-    [  # client version: OpenSSH_8.6p1
+    [  # client version: OpenSSH_8.5p1 - OpenSSH_8.6p1
         'ssh-ed25519-cert-v01@openssh.com', 'ecdsa-sha2-nistp256-cert-v01@openssh.com', 
         'ecdsa-sha2-nistp384-cert-v01@openssh.com', 'ecdsa-sha2-nistp521-cert-v01@openssh.com', 
         'sk-ssh-ed25519-cert-v01@openssh.com', 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com', 

--- a/ssh_proxy_server/plugins/session/cve202014145.py
+++ b/ssh_proxy_server/plugins/session/cve202014145.py
@@ -7,6 +7,15 @@ from paramiko import ECDSAKey
 CVE = 'CVE-2020-14145'
 CLIENT_NAME = 'openssh'
 DEFAULT_ALGORITMS = [
+    [  # client version: OpenSSH_8.6p1
+        'ssh-ed25519-cert-v01@openssh.com', 'ecdsa-sha2-nistp256-cert-v01@openssh.com', 
+        'ecdsa-sha2-nistp384-cert-v01@openssh.com', 'ecdsa-sha2-nistp521-cert-v01@openssh.com', 
+        'sk-ssh-ed25519-cert-v01@openssh.com', 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com', 
+        'rsa-sha2-512-cert-v01@openssh.com', 'rsa-sha2-256-cert-v01@openssh.com', 
+        'ssh-rsa-cert-v01@openssh.com', 'ssh-ed25519', 'ecdsa-sha2-nistp256', 
+        'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'sk-ssh-ed25519@openssh.com', 
+        'sk-ecdsa-sha2-nistp256@openssh.com', 'rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa'],
+
     [  # client version: OpenSSH_8.2p1 - OpenSSH_8.4p1++
         'ecdsa-sha2-nistp256-cert-v01@openssh.com', 'ecdsa-sha2-nistp384-cert-v01@openssh.com',
         'ecdsa-sha2-nistp521-cert-v01@openssh.com', 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com',


### PR DESCRIPTION
I tested if the seciruty vulnerability of OpenSSH <= 8,4 still exists in newer versions.
Turns out it uses a different default-algorithm-list in v8.5/v8.6, but the issue is still not fixed.

I updated the documentation and added the default-algorithm list to compare for v8.5/8.6