### PR TITLE
Update conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,12 +65,12 @@ redirects = {
 }
 
 header = {
-    'title': 'SSH MITM SERVER & content inspection',
-    'summary': 'man in the middle (mitm) server for security audits supporting public key authentication, session hijacking and file manipulation'
+    'title': 'SSH-MITM SERVER & content inspection',
+    'summary': 'man-in-the-middle (mitm) server for security audits supporting public key authentication, session hijacking and file manipulation'
 }
 
 footer = {
-    'title': 'SSH-MITM proxy server is open source',
+    'title': 'SSH-MITM is open source',
     'summary': 'and developed by the community. Be a part of this community and...',
     'linktext': 'contribute to SSH-MITM'
 }
@@ -78,7 +78,7 @@ footer = {
 page_descriptions = {
     'install.html': 'SSH-MITM server is easy to install with Python and PIP',
     'quickstart.html': 'Short guide to setup an intercepting ssh-mitm server with a single command',
-    'advanced-usage.html': 'Guide how to setup a man in the middle server for advanced security audits in large networks and special use cases',
+    'advanced-usage.html': 'Guide on how to setup a man-in-the-middle server for advanced security audits in large networks and special use cases',
     'ssh_vulnerabilities.html': 'Explanation of vulnerabilities related to the ssh protocol',
     'jumphosts.html': 'SSH-MITM should not be used as jump host. This page describes alternatives and security considerations when operating a jump host',
     'portforwarding.html': 'Introduction to port forwarding features of ssh-mitm'


### PR DESCRIPTION
Just a few text corrections.
Open issues:

Previously, we deleted 'proxy server'. Should it say 'server' here?

Capitalization. I would propose that we always capitalize SSH-MITM unless as part of a command. Agreed?