### PR TITLE
Remote host mandatory with port

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ When publickey authentication is possible, a forwarded agent is needed to login 
 
 To start SSH-MITM, all you have to do is run this command in your terminal of choice.
 
-    $ ssh-mitm --remote-host 192.168.0.x
+    $ ssh-mitm --remote-host 192.168.0.x:PORT
 
 Now let's try to connect. SSH-MITM is listening on port 10022.
 

--- a/doc/advanced-usage.rst
+++ b/doc/advanced-usage.rst
@@ -36,7 +36,7 @@ Publickey authentication in SSH-MITM is enabled by default. All you have to do i
 .. code-block:: none
     :linenos:
 
-    $ ssh-mitm --remote-host 192.168.0.x
+    $ ssh-mitm --remote-host 192.168.0.x:PORT
 
 The client must be started with agent forwarding enabled.
 
@@ -206,7 +206,7 @@ To enable agent forwarding, git has to be executed with the ``GIT_SSH_COMMAND`` 
 .. code-block:: bash
 
     # start the ssh server
-    ssh-mitm --remote-host github.com --scp-interface debug_traffic
+    ssh-mitm --remote-host github.com:PORT --scp-interface debug_traffic
 
     # invoke git commands
     GIT_SSH_COMMAND="ssh -A" git clone ssh://git@127.0.0.1:10022/ssh-mitm/ssh-mitm.git

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -58,7 +58,7 @@ In cases, when no agent was forwarded, SSH-MITM can rediredt the session to a ho
                         <p>
                             To start an intercepting mitm-ssh server on Port 10022,
                             all you have to do is run a single command.<br/>
-                            <code>$ ssh-mitm --remote-host 192.168.0.x</code>
+                            <code>$ ssh-mitm --remote-host 192.168.0.x:PORT</code>
                         </p>
                         <p>
                             Now let's try to connect to the ssh-mitm server.<br/>
@@ -131,7 +131,7 @@ All you have to do is run this command in your terminal of choice.
 
 .. code-block:: bash
 
-    $ ssh-mitm --remote-host 192.168.0.x
+    $ ssh-mitm --remote-host 192.168.0.x:PORT
 
 Now let's try to connect to the ssh-mitm server.
 The ssh-mitm server is listening on port 10022.

--- a/ssh_proxy_server/authentication.py
+++ b/ssh_proxy_server/authentication.py
@@ -88,7 +88,7 @@ class Authenticator(BaseModule):
             '--remote-host',
             dest='remote_host',
             type=validate_remote_host,
-            help='remote host to connect to (default 127.0.0.1:22)'
+            help='remote host to connect to (format remote_host:remote_port, default 127.0.0.1:22)'
         )
         plugin_group.add_argument(
             '--auth-username',


### PR DESCRIPTION
Hello everybody
Thanks for the useful tool..
I noticed that the documentation in the remote host section could be improved a bit:
The documentation should be adapted so that it is clear that the remote host must be specified in the format remote_host:remote_port.