### PR TITLE
allow mkdir to work with default attr.st_mode

### DIFF
--- a/sshmitm/interfaces/sftp.py
+++ b/sshmitm/interfaces/sftp.py
@@ -60,8 +60,6 @@ class SFTPProxyServerInterface(BaseSFTPServerInterface):
         self.session.sftp_client_ready.wait()
         if self.session.sftp_client is None:
             raise MissingClient("self.session.sftp_client is None!")
-        if attr.st_mode is None:
-            return paramiko.sftp.SFTP_FAILURE
         return self.session.sftp_client.mkdir(path, attr.st_mode)
 
     def open(self, path: str, flags: int, attr: SFTPAttributes) -> Union[SFTPHandle, int]:

--- a/sshmitm/interfaces/sftp.py
+++ b/sshmitm/interfaces/sftp.py
@@ -60,6 +60,8 @@ class SFTPProxyServerInterface(BaseSFTPServerInterface):
         self.session.sftp_client_ready.wait()
         if self.session.sftp_client is None:
             raise MissingClient("self.session.sftp_client is None!")
+        if attr.st_mode is None:
+            return self.session.sftp_client.mkdir(path) 
         return self.session.sftp_client.mkdir(path, attr.st_mode)
 
     def open(self, path: str, flags: int, attr: SFTPAttributes) -> Union[SFTPHandle, int]:


### PR DESCRIPTION

on mkdir, allow defaults instead of blocking on empty `attr.st_mode`