### PR TITLE
Add new option to store output of non-interactive commands

### DIFF
--- a/sshmitm/forwarders/scp.py
+++ b/sshmitm/forwarders/scp.py
@@ -241,9 +241,13 @@ class SCPForwarder(SCPBaseForwarder):
         self.got_c_command = False
         return self.process_data(traffic)
 
+    def process_command_data(self, command: bytes, traffic: bytes, isclient: bool) -> bytes:
+        return traffic
+
     def handle_traffic(self, traffic: bytes, isclient: bool) -> bytes:
         if self.session.scp_command.startswith(b'scp'):
             return self.handle_scp(traffic)
-        if self.session.scp_command.startswith(b"mosh-server"):
+        elif self.session.scp_command.startswith(b"mosh-server"):
             return handle_mosh(self.session, traffic, isclient)
-        return traffic
+        else:
+            return self.process_command_data(self.session.scp_command, traffic, isclient)

--- a/sshmitm/plugins/scp/store_file.py
+++ b/sshmitm/plugins/scp/store_file.py
@@ -36,6 +36,13 @@ class SCPStorageForwarder(SCPForwarder):
             action='store_true',
             help='store files from scp'
         )
+        plugin_group.add_argument(
+            '--store-command-data',
+            dest='store_command_data',
+            action='store_true',
+            help='store data from non-interactive ssh commands'
+        )
+
 
     def __init__(self, session: 'sshmitm.session.Session') -> None:
         super().__init__(session)
@@ -43,6 +50,7 @@ class SCPStorageForwarder(SCPForwarder):
         self.scp_storage_dir = None
         if self.session.session_log_dir:
             self.scp_storage_dir = os.path.join(self.session.session_log_dir, 'scp')
+            self.command_storage_dir = os.path.join(self.session.session_log_dir, 'command')
 
     def process_data(self, traffic: bytes) -> bytes:
         if not self.args.store_scp_files or not self.scp_storage_dir:
@@ -62,4 +70,23 @@ class SCPStorageForwarder(SCPForwarder):
         if self.file_name and self.bytes_remaining == 0:
             logging.info("file %s -> %s", self.file_name, self.file_id)
             self.file_id = None
+        return traffic
+
+    def store_command_data(self, file_id, traffic: bytes, isclient: bool):
+        if isclient:
+            suffix = '.client'
+        else:
+            suffix = '.server'
+        output_path = os.path.join(self.command_storage_dir, file_id + suffix)
+        with open(output_path, 'a+b') as tmp_file:
+            tmp_file.write(traffic)
+
+    def process_command_data(self, command: bytes, traffic: bytes, isclient: bool) -> bytes:
+        if not self.args.store_command_data or not self.command_storage_dir:
+            return traffic
+        os.makedirs(self.command_storage_dir, exist_ok=True)
+        if self.file_id is None:
+            self.file_id = str(uuid.uuid4())
+            self.store_command_data(self.file_id, command, True)
+        self.store_command_data(self.file_id, traffic, isclient)
         return traffic


### PR DESCRIPTION
Add new flag `--store-command-data` that (if enabled) makes ssh-mitm store the input and output of non-interactive ssh commands (that are neither mosh nor scp)