### PR TITLE
replace pkg_resources for python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Topic :: System :: Networking",
     "Development Status :: 5 - Production/Stable",

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,7 @@
 argcomplete
 colored
+importlib_metadata>=4.6; python_version < "3.10"
+importlib_resources>=5.0; python_version < "3.10"
 packaging
 paramiko>=3.4,<3.5
 python-json-logger

--- a/sshmitm/appimage.py
+++ b/sshmitm/appimage.py
@@ -36,9 +36,10 @@ import sys
 from configparser import ConfigParser
 from functools import cached_property
 from importlib.metadata import EntryPoint, entry_points
-from importlib.resources import files
 from typing import TYPE_CHECKING, Dict, Optional
 from venv import EnvBuilder
+
+from sshmitm.utils import resources
 
 if TYPE_CHECKING:
     from types import SimpleNamespace
@@ -101,9 +102,8 @@ class AppStarter:
         """
         self.config = ConfigParser()
         self.config.read_string(DEFAULT_CONFIG)
-        config_path = files('sshmitm.data').joinpath('appimage.ini')
-        if config_path.exists():
-            self.config.read(config_path)
+        config_path = resources.files("sshmitm.data").joinpath("appimage.ini")
+        self.config.read_string(config_path.read_text())
 
         self.default_ep = self.config.get("appimage", "entry_point", fallback=None)
         argv0_complete = os.environ.get("ARGV0")

--- a/sshmitm/appimage.py
+++ b/sshmitm/appimage.py
@@ -103,7 +103,7 @@ class AppStarter:
         self.config = ConfigParser()
         self.config.read_string(DEFAULT_CONFIG)
         config_path = resources.files("sshmitm.data").joinpath("appimage.ini")
-        self.config.read_string(config_path.read_text())
+        self.config.read_string(config_path.read_text(encoding="utf-8"))
 
         self.default_ep = self.config.get("appimage", "entry_point", fallback=None)
         argv0_complete = os.environ.get("ARGV0")

--- a/sshmitm/config.py
+++ b/sshmitm/config.py
@@ -1,12 +1,13 @@
 import os
 from configparser import ConfigParser
 
-import pkg_resources
+from sshmitm.utils import resources
 
 CONFIGFILE = ConfigParser()
 
 # read default config
-CONFIGFILE.read(pkg_resources.resource_filename("sshmitm", "data/default.ini"))
+conf = resources.files("sshmitm") / "data/default.ini"
+CONFIGFILE.read_string(conf.read_text())
 
 configfile_path_list = [
     "/etc/ssh-mitm.ini",

--- a/sshmitm/interfaces/server.py
+++ b/sshmitm/interfaces/server.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import TYPE_CHECKING, Any, ByteString, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, Union
 
 import paramiko
 from paramiko.pkey import PKey
@@ -448,7 +448,7 @@ class ServerInterface(BaseServerInterface):
         channel: paramiko.Channel,
         single_connection: bool,
         auth_protocol: str,
-        auth_cookie: ByteString,
+        auth_cookie: Union[bytes, bytearray],
         screen_number: int,
     ) -> bool:
         logging.debug(

--- a/sshmitm/moduleparser/modules.py
+++ b/sshmitm/moduleparser/modules.py
@@ -15,11 +15,10 @@ from typing import (
     cast,
 )
 
-import pkg_resources
-
 from sshmitm.moduleparser.baseparser import BaseModuleArgumentParser
 from sshmitm.moduleparser.exceptions import InvalidModuleArguments, ModuleError
 from sshmitm.moduleparser.utils import load_module, set_module_kwargs
+from sshmitm.utils import metadata
 
 if TYPE_CHECKING:
     from sshmitm.moduleparser import ModuleParser
@@ -122,8 +121,8 @@ class BaseModule(ABC):
     def load_from_entrypoint(
         name: str, entry_point_class: Type["BaseModule"]
     ) -> Optional[Type["BaseModule"]]:
-        for entry_point in pkg_resources.iter_entry_points(entry_point_class.__name__):
-            if name in (entry_point.name, entry_point.module_name):
+        for entry_point in metadata.entry_points(group=entry_point_class.__name__):
+            if name in (entry_point.name, entry_point.module):
                 return cast(Type[BaseModule], entry_point.load())
         return None
 

--- a/sshmitm/moduleparser/parser.py
+++ b/sshmitm/moduleparser/parser.py
@@ -36,13 +36,13 @@ from typing import (
 )
 
 import argcomplete
-import pkg_resources
 
 from sshmitm.moduleparser.baseparser import BaseModuleArgumentParser
 from sshmitm.moduleparser.exceptions import ModuleError
 from sshmitm.moduleparser.formatter import ModuleFormatter
 from sshmitm.moduleparser.modules import BaseModule, SubCommand
 from sshmitm.moduleparser.utils import load_module, set_module_kwargs
+from sshmitm.utils import metadata
 
 if TYPE_CHECKING:
     from configparser import ConfigParser
@@ -92,7 +92,7 @@ class ModuleParser(
             )
             self.subcommand.required = True
 
-        for entry_point in pkg_resources.iter_entry_points(SubCommand.__name__):
+        for entry_point in metadata.entry_points(group=SubCommand.__name__):
             if entry_point.name in self._registered_subcommands:
                 continue
             subcommand_cls = cast(Type[SubCommand], entry_point.load())

--- a/sshmitm/moduleparser/utils.py
+++ b/sshmitm/moduleparser/utils.py
@@ -1,10 +1,10 @@
 import argparse
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Type, Union
 
-import pkg_resources
 from colored.colored import attr, fg  # type: ignore[import-untyped]
 
 from sshmitm.logging import Colors
+from sshmitm.utils import metadata
 
 if TYPE_CHECKING:
     from sshmitm.moduleparser.modules import BaseModule
@@ -24,10 +24,10 @@ def load_module(entry_point_class: Type["BaseModule"]) -> Type["argparse.Action"
             del parser
             del option_string
             if values:
-                for entry_point in pkg_resources.iter_entry_points(
-                    entry_point_class.__name__
+                for entry_point in metadata.entry_points(
+                    group=entry_point_class.__name__
                 ):
-                    if values in (entry_point.name, entry_point.module_name):
+                    if values in (entry_point.name, entry_point.module):
                         values = [entry_point.load()]
                         setattr(namespace, self.dest, values[0] if values else None)
                         break
@@ -39,7 +39,7 @@ def set_module_kwargs(
     entry_point_class: Type["BaseModule"], **kwargs: Any
 ) -> Dict[str, Any]:
     entry_points = sorted(
-        pkg_resources.iter_entry_points(entry_point_class.__name__),
+        metadata.entry_points(group=entry_point_class.__name__),
         key=lambda x: x.name,
     )
     if not entry_points:

--- a/sshmitm/plugins/session/key_negotiation.py
+++ b/sshmitm/plugins/session/key_negotiation.py
@@ -2,7 +2,6 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
-import pkg_resources
 import yaml
 from colored.colored import attr, fg  # type: ignore[import-untyped]
 from paramiko import Transport, common
@@ -12,6 +11,7 @@ from rich.markup import escape
 
 from sshmitm.logging import Colors
 from sshmitm.plugins.session.clientaudit import SSHClientAudit
+from sshmitm.utils import resources
 
 if TYPE_CHECKING:
     import sshmitm
@@ -77,9 +77,8 @@ class KeyNegotiationData:
         vulnerability_list = None
         client_version = self.client_version.lower()
         try:
-            vulndb = pkg_resources.resource_filename("sshmitm", "data/client_info.yml")
-            with open(vulndb, encoding="utf-8") as file:
-                vulnerability_list = yaml.safe_load(file)
+            vulndb = resources.files("sshmitm") / "data/client_info.yml"
+            vulnerability_list = yaml.safe_load(vulndb.read_text(encoding="utf-8"))
         except Exception:  # pylint: disable=broad-exception-caught
             logging.exception("Error loading vulnerability database")
             return

--- a/sshmitm/utils.py
+++ b/sshmitm/utils.py
@@ -1,4 +1,13 @@
 import binascii
+import sys
+
+__all__ = ["format_hex", "metadata", "resources"]
+
+if sys.version_info >= (3, 10):
+    from importlib import metadata, resources
+else:
+    import importlib_metadata as metadata
+    import importlib_resources as resources
 
 
 def format_hex(data: bytes, hexwidth: int = 19) -> str:


### PR DESCRIPTION
Python 3.12 has removed bundled `setuptools` (aka `pkg_resources`): https://docs.python.org/3.12/whatsnew/3.12.html#removed

`importlib` provides direct replacements but due to API changes, backports are needed for <3.10
