### PR TITLE
Fix connection for IPv6 upstream SSH servers

### DIFF
--- a/sshmitm/authentication.py
+++ b/sshmitm/authentication.py
@@ -82,8 +82,7 @@ class PublicKeyEnumerator:
         if self.connected:
             return
         self.connected = True
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.sock.connect(self.remote_address)
+        self.sock = socket.create_connection(self.remote_address)
         self.transport = paramiko.transport.Transport(self.sock)
         self.transport.start_client()
 


### PR DESCRIPTION
The socket.create_connection API alllows hostnames and IPv4 and IPv6 addresses to be passed. Depending on the data passed, the hostname will be resolved and an IPv4 or IPv6 channel will be opened. Beforehand, only IPv4 channels were possible. See https://docs.python.org/3/library/socket.html#socket.create_connection

This change allows calls like `ssh-mitm -d server --remote-host fd50:dead:beef::1337` again. Bug came into effect by 4fc3ef418847c35d17d0c427e2701b33a03c323c.