### PR TITLE
Adds message logging to a remote HTTP server

### DIFF
--- a/doc/get_started/configuration.rst
+++ b/doc/get_started/configuration.rst
@@ -102,6 +102,7 @@
 
       [sshmitm.session:Session]
       session-log-dir =
+      log-transmit_dst =
 
    :option string session-log-dir: |br|
       Specifies the directory where session logs will be stored.

--- a/doc/get_started/configuration.rst
+++ b/doc/get_started/configuration.rst
@@ -102,7 +102,7 @@
 
       [sshmitm.session:Session]
       session-log-dir =
-      log-transmit_dst =
+      log-webhook-dest =
 
    :option string session-log-dir: |br|
       Specifies the directory where session logs will be stored.

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ pytz
 pyyaml
 rich
 wrapt
+requests

--- a/sshmitm/data/default.ini
+++ b/sshmitm/data/default.ini
@@ -31,6 +31,7 @@ banner-name =
 
 [sshmitm.session:Session]
 session-log-dir =
+log-transmit_dst =
 
 ##################################
 # Authentication-Plugins

--- a/sshmitm/data/default.ini
+++ b/sshmitm/data/default.ini
@@ -31,7 +31,7 @@ banner-name =
 
 [sshmitm.session:Session]
 session-log-dir =
-log-transmit_dst =
+log-webhook-dest =
 
 ##################################
 # Authentication-Plugins

--- a/sshmitm/forwarders/ssh.py
+++ b/sshmitm/forwarders/ssh.py
@@ -67,6 +67,9 @@ class SSHForwarder(SSHBaseForwarder):
             buf: bytes = self.client_channel.recv(self.BUF_LEN)
             buf = self.stdin(buf)
             self.server_channel.sendall(buf)
+            self.session.log_forwarder.forward_client_msg(
+                client_msg=buf.decode("utf-8"),
+            )
 
     def forward_stdout(self) -> None:
         if self.server_channel.recv_ready():
@@ -74,6 +77,10 @@ class SSHForwarder(SSHBaseForwarder):
             buf = self.stdout(buf)
             if self.client_channel is not None:
                 self.client_channel.sendall(buf)
+                self.session.log_forwarder.forward_server_msg(
+                    client_msg=None,
+                    server_msg=buf.decode("utf-8"),
+                )
 
     def forward_extra(self) -> None:
         pass
@@ -84,6 +91,10 @@ class SSHForwarder(SSHBaseForwarder):
             buf = self.stderr(buf)
             if self.client_channel is not None:
                 self.client_channel.sendall_stderr(buf)
+                self.session.log_forwarder.forward_server_error_message(
+                    client_msg=None,
+                    server_msg_err=buf.decode("utf-8"),
+                )
 
     def stdin(self, text: bytes) -> bytes:
         return text

--- a/sshmitm/server/__init__.py
+++ b/sshmitm/server/__init__.py
@@ -61,6 +61,7 @@ class SSHProxyServer:
         session_class: Type[Session] = Session,
         banner_name: Optional[str] = None,
         debug: bool = False,
+        log_webhook_dest: Optional[str] = None,
     ) -> None:
         self._threads: List[threading.Thread] = []
         self._hostkey: Optional[PKey] = None
@@ -96,6 +97,7 @@ class SSHProxyServer:
         self.session_class: Type[Session] = session_class
         self.banner_name: Optional[str] = banner_name
         self.debug: bool = debug
+        self.log_webhook_dest: Optional[str] = log_webhook_dest
 
         try:
             self.generate_host_key()
@@ -339,7 +341,13 @@ class SSHProxyServer:
     ) -> None:
         try:
             with self.session_class(
-                self, client, addr, self.authenticator, remoteaddr, self.banner_name
+                self,
+                client,
+                addr,
+                self.authenticator,
+                remoteaddr,
+                self.banner_name,
+                self.log_webhook_dest,
             ) as session:
                 logging.debug(
                     "incoming connection from %s to %s", str(addr), remoteaddr

--- a/sshmitm/server/cli.py
+++ b/sshmitm/server/cli.py
@@ -2,9 +2,7 @@ import argparse
 from typing import Optional
 
 from sshmitm import __version__ as ssh_mitm_version
-from sshmitm.authentication import (
-    Authenticator,
-)
+from sshmitm.authentication import Authenticator
 from sshmitm.forwarders.scp import SCPBaseForwarder
 from sshmitm.forwarders.sftp import SFTPHandlerBasePlugin
 from sshmitm.forwarders.ssh import SSHBaseForwarder
@@ -12,12 +10,8 @@ from sshmitm.forwarders.tunnel import (
     LocalPortForwardingBaseForwarder,
     RemotePortForwardingBaseForwarder,
 )
-from sshmitm.interfaces.server import (
-    BaseServerInterface,
-)
-from sshmitm.interfaces.sftp import (
-    BaseSFTPServerInterface,
-)
+from sshmitm.interfaces.server import BaseServerInterface
+from sshmitm.interfaces.sftp import BaseSFTPServerInterface
 from sshmitm.moduleparser import SubCommand
 from sshmitm.server import SSHProxyServer
 from sshmitm.session import BaseSession
@@ -137,6 +131,11 @@ class SSHServerModules(SubCommand):
             default=f"SSHMITM_{ssh_mitm_version}",
             help="Sets a custom SSH server banner presented to clients during the initial connection. Default: ``SSH-2.0-SSHMITM_<version>``.",
         )
+        parser_group.add_argument(
+            "--log-webhook-dest",
+            dest="log_webhook_dest",
+            help="Transmits SSH commands and responses to a remote HTTP server for log collection and analyzation",
+        )
 
     def execute(self, args: argparse.Namespace) -> None:
         if args.request_agent_breakin:
@@ -159,6 +158,7 @@ class SSHServerModules(SubCommand):
             transparent=args.transparent,
             banner_name=args.banner_name,
             debug=args.debug,
+            log_webhook_dest=args.log_webhook_dest,
         )
         proxy.print_serverinfo(args.log_format == "json")
         proxy.start()

--- a/sshmitm/tools/log_collection.py
+++ b/sshmitm/tools/log_collection.py
@@ -1,0 +1,263 @@
+# pylint: disable=too-many-arguments
+import datetime
+import hashlib
+import logging
+from threading import Thread
+from typing import Optional
+
+import requests
+
+
+class LogForwarder:
+    """
+    The constructed payload aims to fulfill field definition as defined by the Elastic Common Schema (https://www.elastic.co/docs/reference/ecs/ecs-field-reference).
+    """
+
+    def __init__(
+        self,
+        client_ip: str,
+        client_port: int,
+        server_ip: str,
+        server_port: int,
+        log_webhook_dest: Optional[str] = None,
+    ) -> None:
+        self.client_ip = client_ip
+        self.client_port = client_port
+        self.server_ip = server_ip
+        self.server_port = server_port
+
+        self.log_webhook_dest = log_webhook_dest
+
+        self.username = None
+        self.password = None
+        self.cipher = None
+
+        self.server_server_extensions = None
+        self.server_proto_version = None
+        self.server_software_version = None
+        self.server_preferred_ciphers = None
+        self.server_preferred_kex = None
+        self.server_preferred_macs = None
+        self.server_preferred_compression = None
+        self.server_hassh = None
+
+        self.client_server_extensions = None
+        self.client_proto_version = None
+        self.client_software_version = None
+        self.client_preferred_ciphers = None
+        self.client_preferred_kex = None
+        self.client_preferred_macs = None
+        self.client_preferred_compression = None
+        self.client_hassh = None
+
+    def set_credentials(self, username: str, password: str) -> None:
+        self.username = username
+        self.password = password
+
+    def set_cipher(self, cipher: str) -> None:
+        self.cipher = cipher
+
+    def set_server_transport_metadata(
+        self,
+        server_extensions: str,
+        proto_version: str,
+        software_version: str,
+        preferred_ciphers: tuple,
+        preferred_kex: tuple,
+        preferred_macs: tuple,
+        preferred_compression: tuple,
+    ) -> None:
+        self.server_server_extensions = server_extensions
+        self.server_proto_version = proto_version
+        self.server_software_version = software_version
+        self.server_preferred_ciphers = ",".join(preferred_ciphers)
+        self.server_preferred_kex = ",".join(preferred_kex)
+        self.server_preferred_macs = ",".join(preferred_macs)
+        self.server_preferred_compression = ",".join(preferred_compression)
+        # hassh as defined here: https://github.com/salesforce/hassh
+        # ruff: noqa: S324
+        self.server_hassh = hashlib.md5(  # nosec
+            f"{self.server_preferred_ciphers};{self.server_preferred_kex};{self.server_preferred_macs};{self.server_preferred_compression}".encode(
+                "utf-8"
+            )
+        ).hexdigest()
+
+    def set_client_transport_metadata(
+        self,
+        server_extensions: str,
+        proto_version: str,
+        software_version: str,
+        preferred_ciphers: tuple,
+        preferred_kex: tuple,
+        preferred_macs: tuple,
+        preferred_compression: tuple,
+    ) -> None:
+        self.client_server_extensions = server_extensions
+        self.client_proto_version = proto_version
+        self.client_software_version = software_version
+        self.client_preferred_ciphers = ",".join(preferred_ciphers)
+        self.client_preferred_kex = ",".join(preferred_kex)
+        self.client_preferred_macs = ",".join(preferred_macs)
+        self.client_preferred_compression = ",".join(preferred_compression)
+        # hassh as defined here: https://github.com/salesforce/hassh
+        # ruff: noqa: S324
+        self.client_hassh = hashlib.md5(  # nosec
+            f"{self.client_preferred_ciphers};{self.client_preferred_kex};{self.client_preferred_macs};{self.client_preferred_compression}".encode(
+                "utf-8"
+            )
+        ).hexdigest()
+
+    def __build_payload(
+        self,
+        event_outcome: str,
+        client_msg: Optional[str] = None,
+        client_msg_err: Optional[str] = None,
+        server_msg: Optional[str] = None,
+        server_msg_err: Optional[str] = None,
+    ) -> dict:
+        current_timestamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+        return {
+            # Using current timestamp in @timestamp, because we don't have access to the actual creation timestamp of the ssh action from the source side.
+            "@timestamp": current_timestamp,
+            "event": {
+                "created": current_timestamp,
+                "outcome": event_outcome,
+            },
+            "ssh": {
+                # The SSH payload body is based on the following sources:
+                # - Suricata: https://docs.suricata.io/en/suricata-6.0.16/output/eve/eve-json-format.html#event-type-ssh
+                # - Elastic Common Schema: https://www.elastic.co/docs/reference/ecs/ecs-field-reference
+                "cipher": self.cipher,
+                "client": {
+                    "proto_version": self.client_proto_version,
+                    "software_version": self.client_software_version,
+                    "preferred_kex": self.client_preferred_kex,
+                    "preferred_ciphers": self.client_preferred_ciphers,
+                    "preferred_macs": self.client_preferred_macs,
+                    "preferred_compression": self.client_preferred_compression,
+                    "hassh": self.client_hassh,
+                    "message": client_msg,
+                    "error_message": client_msg_err,
+                },
+                "server": {
+                    "proto_version": self.server_proto_version,
+                    "software_version": self.server_software_version,
+                    "preferred_kex": self.server_preferred_kex,
+                    "preferred_ciphers": self.server_preferred_ciphers,
+                    "preferred_macs": self.server_preferred_macs,
+                    "preferred_compression": self.server_preferred_compression,
+                    "hassh": self.server_hassh,
+                    "message": server_msg,
+                    "error_message": server_msg_err,
+                },
+            },
+            "client": {
+                "ip": self.client_ip,
+                "port": self.client_port,
+            },
+            "server": {
+                "ip": self.server_ip,
+                "port": self.server_port,
+                "user": {
+                    "name": self.username,
+                    "password": self.password,
+                },
+            },
+        }
+
+    def forward_client_msg(self, client_msg: str) -> None:
+        if self.log_webhook_dest is None:
+            return
+
+        payload = self.__build_payload(
+            client_msg=client_msg,
+            event_outcome="success",
+        )
+        payload = payload | {
+            "destination": {"ip": self.server_ip, "port": self.server_port},
+            "source": {"ip": self.client_ip, "port": self.client_port},
+        }
+        thread = Thread(
+            target=LogForwarder.__send_payload, args=(self.log_webhook_dest, payload)
+        )
+        thread.start()
+
+    def forward_server_msg(self, server_msg: str, client_msg: str) -> None:
+        if self.log_webhook_dest is None:
+            return
+
+        payload = self.__build_payload(
+            client_msg=client_msg,
+            event_outcome="success",
+            server_msg=server_msg,
+        )
+        payload = payload | {
+            "destination": {"ip": self.client_ip, "port": self.client_port},
+            "source": {"ip": self.server_ip, "port": self.server_port},
+        }
+        thread = Thread(
+            target=LogForwarder.__send_payload, args=(self.log_webhook_dest, payload)
+        )
+        thread.start()
+
+    def forward_client_error_message(
+        self, client_msg_err: str, server_msg: str
+    ) -> None:
+        if self.log_webhook_dest is None:
+            return
+
+        payload = self.__build_payload(
+            client_msg_err=client_msg_err,
+            event_outcome="failure",
+            server_msg=server_msg,
+        )
+        payload = payload | {
+            "source": {"ip": self.client_ip, "port": self.client_port},
+            "destination": {"ip": self.server_ip, "port": self.server_port},
+        }
+        thread = Thread(
+            target=LogForwarder.__send_payload, args=(self.log_webhook_dest, payload)
+        )
+        thread.start()
+
+    def forward_server_error_message(
+        self, client_msg: str, server_msg_err: str
+    ) -> None:
+        if self.log_webhook_dest is None:
+            return
+
+        payload = self.__build_payload(
+            client_msg=client_msg,
+            event_outcome="failure",
+            server_msg_err=server_msg_err,
+        )
+        payload = payload | {
+            "destination": {"ip": self.client_ip, "port": self.client_port},
+            "source": {"ip": self.server_ip, "port": self.server_port},
+        }
+        thread = Thread(
+            target=LogForwarder.__send_payload, args=(self.log_webhook_dest, payload)
+        )
+        thread.start()
+
+    @staticmethod
+    def __send_payload(webhook_dst: str, payload: dict) -> None:
+        """
+        Send the payload to the webhook destination.
+        """
+        try:
+            response = requests.post(webhook_dst, json=payload, timeout=10)
+        except requests.exceptions.RequestException as err:
+            # Report transmit exception in STDOUT and don't enforce the parent thread to terminate.
+            # ruff: noqa: TRY401
+            logging.exception(err)
+            return
+
+        logging.debug("Webhook sent to %s", webhook_dst)
+
+        if response.status_code >= 400:
+            logging.error(
+                "Webhook failed with status code %s. Response: %s",
+                response.status_code,
+                response.text,
+            )


### PR DESCRIPTION
Hi,

I have implemented a second option for message logging and I hope it is useful for the project.

The new LogForwarder class ships recorded messages (commands and responses) along with metadata to a remote HTTP server. This HTTP logging can be enabled with the command line parameter "--log-webhook-dest={{URL}}".

A message and its metadata are send in a JSON request to the HTTP server. The JSON schema follows the Elastic Common Schema (https://www.elastic.co/docs/reference/ecs/ecs-field-reference).

I have implemented usage in the forwarder classes for netconf, scp and ssh.

Two notable points:
1. The JSON schema defines various metadata, such as client and server IP, a fingerprint of client and server and timestamp. 
2. I implemented scp logging so that for each message a JSON is send to the HTTP server. This means that a command is logged twice. Once without its response from the server and a few milliseconds later with a response. This way all communication is logged and a command is not dropped because the server does not respond. One can configure their HTTP server to ignore the first event, if the response message is empty.
